### PR TITLE
Adjust the look and behavior of the preview markdown link

### DIFF
--- a/app/assets/javascripts/tips.js.coffee
+++ b/app/assets/javascripts/tips.js.coffee
@@ -45,6 +45,7 @@ jQuery ->
         console.log "Oh noes"
 
       $("#write-input").hide()
+      $('.cheatsheet').hide()
       $("#code-preview").show()
       $("#code-preview-tab").parent().addClass("active")
       $("#write-tab").parent().removeClass("active")
@@ -56,6 +57,7 @@ jQuery ->
     $("#code-preview-tab").html("Preview")
     unless $("#write-tab").parent().hasClass("active")
       $("#write-input").show()
+      $('.cheatsheet').show()
       $("#code-preview").hide()
       $("#code-preview-tab").parent().removeClass("active")
       $("#write-tab").parent().addClass("active")

--- a/app/assets/javascripts/tips.js.coffee
+++ b/app/assets/javascripts/tips.js.coffee
@@ -17,45 +17,45 @@ charCount = (selector, limit, counter_display) ->
 
 jQuery ->
   # Initialize the counters for Title and Description
-  charCount "#tip_title", 50, ".tip-title-countdown"
-  charCount "#tip_description", 250, ".tip-description-countdown"
+  charCount "#tip-title", 50, ".tip-title-countdown"
+  charCount "#tip-description", 250, ".tip-description-countdown"
   
   # Monitor the changes for Title and Description
-  $("#tip_title, #tip_description").change ->
-    charCount "#tip_title", 50, ".tip-title-countdown"
-    charCount  "#tip_description", 250, ".tip-description-countdown"
+  $("#tip-title, #tip-description").change ->
+    charCount "#tip-title", 50, ".tip-title-countdown"
+    charCount  "#tip-description", 250, ".tip-description-countdown"
   
   # Monitor typing with the Title and Description
-  $("#tip_title, #tip_description").keyup ->
-    charCount "#tip_title", 50, ".tip-title-countdown"
-    charCount  "#tip_description", 250, ".tip-description-countdown"
+  $("#tip-title, #tip-description").keyup ->
+    charCount "#tip-title", 50, ".tip-title-countdown"
+    charCount  "#tip-description", 250, ".tip-description-countdown"
 
   # Send the tip body to Markdown parser to generate the preview and show preview
-  $('#code_preview_tab').click (event) ->
+  $('#code-preview-tab').click (event) ->
     event.preventDefault()
     
-    unless $("#code_preview_tab").parent().hasClass("active") 
-      $("#code_preview_tab").addClass("load").html("loading...")
+    unless $("#code-preview-tab").parent().hasClass("active") 
+      $("#code-preview-tab").addClass("load").html("loading...")
       url = "/tips/preview"
       body = { body: $("#tip_body").val() }
       $.post(url, body).then ->   
-        $("#code_preview_tab").addClass("preview").html("Preview")
+        $("#code-preview-tab").addClass("preview").html("Preview")
         console.log("success")
       .fail ->
         console.log "Oh noes"
 
-      $("#write_input").hide()
-      $("#code_preview").show()
-      $("#code_preview_tab").parent().addClass("active")
-      $("#write_tab").parent().removeClass("active")
+      $("#write-input").hide()
+      $("#code-preview").show()
+      $("#code-preview-tab").parent().addClass("active")
+      $("#write-tab").parent().removeClass("active")
       
 
   # Switch back to tip body input
-  $('#write_tab').click (event) ->
+  $('#write-tab').click (event) ->
     event.preventDefault()
-    $("#code_preview_tab").html("Preview")
-    unless $("#write_tab").parent().hasClass("active")
-      $("#write_input").show()
-      $("#code_preview").hide()
-      $("#code_preview_tab").parent().removeClass("active")
-      $("#write_tab").parent().addClass("active")
+    $("#code-preview-tab").html("Preview")
+    unless $("#write-tab").parent().hasClass("active")
+      $("#write-input").show()
+      $("#code-preview").hide()
+      $("#code-preview-tab").parent().removeClass("active")
+      $("#write-tab").parent().addClass("active")

--- a/app/assets/stylesheets/theme.css.scss
+++ b/app/assets/stylesheets/theme.css.scss
@@ -191,12 +191,12 @@ ul.devise-links {
   }
 }
 
-.tip_body_wrapper {
+.tip-body-wrapper {
   border: solid 1px #ddd;
   border-top: none;
   padding: 15px 15px 0;
   margin-bottom: 2em;
-  #code_preview {
+  #code-preview {
     max-height: 400px;
     overflow: scroll;
   }
@@ -326,7 +326,7 @@ pre {
   padding-bottom: 15px;
 }
 
-.tip_body_wrapper p {
+.tip-body-wrapper p {
   
   font-size: 14px !important;
   margin: 5px 0 0;
@@ -334,7 +334,7 @@ pre {
   padding-bottom: 10px;
 }
 
-.tip_body_wrapper p a {
+.tip-body-wrapper p a {
   font-weight: bold;
   color: #991a20;
   cursor: pointer; 

--- a/app/assets/stylesheets/theme.css.scss
+++ b/app/assets/stylesheets/theme.css.scss
@@ -200,7 +200,31 @@ ul.devise-links {
     max-height: 400px;
     overflow: scroll;
   }
+  .cheatsheet {
+    color: lighten($gray-base, 60%);
+    font-size: 12px;
+    a {
+      font-weight: bold;
+      color: lighten($link-color, 20%);
+      cursor: pointer;
+    }
+  }
 }
+
+// .tip-body-wrapper p {
+  
+//   font-size: 14px !important;
+//   margin: 5px 0 0;
+//   line-height: 1.3;
+//   padding-bottom: 10px;
+// }
+
+// .tip-body-wrapper p a {
+//   font-weight: bold;
+//   color: #991a20;
+//   cursor: pointer; 
+//   cursor: hand;
+// }
 
 // User profile
 
@@ -324,21 +348,6 @@ pre {
 .modal-header {
   position: relative;
   padding-bottom: 15px;
-}
-
-.tip-body-wrapper p {
-  
-  font-size: 14px !important;
-  margin: 5px 0 0;
-  line-height: 1.3;
-  padding-bottom: 10px;
-}
-
-.tip-body-wrapper p a {
-  font-weight: bold;
-  color: #991a20;
-  cursor: pointer; 
-  cursor: hand;
 }
 
 .modal-body p {

--- a/app/views/tips/_form.html.erb
+++ b/app/views/tips/_form.html.erb
@@ -1,27 +1,29 @@
 <div class="form-group">
-  <%= f.text_field :title, class: 'form-control input-lg', placeholder: 'Tip title' %>
+  <%= f.text_field :title, id: 'tip-title', class: 'form-control input-lg', placeholder: 'Tip title' %>
   <p class="help-block">
   	<span class="tip-title-countdown"></span>
   </p>
 </div>
 
 <div class="form-group">
-  <%= f.text_area :description, rows: 4, class: 'form-control', placeholder: 'Short tip description' %>
+  <%= f.text_area :description, rows: 4,id: 'tip-description', class: 'form-control', placeholder: 'Short tip description' %>
   <p class="help-block">
   	<span class="tip-description-countdown"></span>
   </p>
 </div>
 
 <ul class="nav nav-tabs" role="tablist">
-  <li class="active"><a href="#" id="write_tab">Write</a></li>
-  <li><a href="#" id="code_preview_tab">Preview</a></li>
+  <li class="active"><a href="#" id="write-tab">Write</a></li>
+  <li><a href="#" id="code-preview-tab">Preview</a></li>
 </ul>
-<div class="tip_body_wrapper tip">
-  <div class="form-group" id="write_input">
+<div class="tip-body-wrapper tip">
+  <div class="form-group" id="write-input">
     <%= f.text_area :body, rows: 12, class: 'form-control', placeholder: 'Detailed tip content and code' %>
   </div>
-  <div id="code_preview" class="body" style="display:none;"></div>
-  <p> Reference this <a data-toggle="modal" data-target="#myModal">Markdown Cheatsheet</a> for syntax examples for formatting your post.</p>
+  <div id="code-preview" class="body" style="display:none;"></div>
+  
+  <p class="cheatsheet">Reference this <a data-toggle="modal" data-target="#myModal">Markdown Cheatsheet</a> for syntax examples for formatting your post.</p>
+  
   <%= render 'modal', f: f %>
 </div>
 

--- a/app/views/tips/preview.js.erb
+++ b/app/views/tips/preview.js.erb
@@ -1,1 +1,1 @@
-$('#code_preview').html("<%=j @preview %>")
+$('#code-preview').html("<%=j @preview %>")


### PR DESCRIPTION
I made some adjustments. It is good to follow a standard when using IDs and CLASSes in jQuery and HTML/CSS. The IDs and CLASSes should use hyphens to separate the words, not underscores.

For some reason the automatically generated IDs for HTML elements use underscores. For this reason, it is a good practice to explicitly set the `id:` option.

The markdown cheatsheet now disappears in the preview.